### PR TITLE
Modify the invokation keyword:

### DIFF
--- a/commands/bump.md
+++ b/commands/bump.md
@@ -21,7 +21,7 @@ Leaving an expired TODO untouched is a bad practice for two reasons:
 
 #### <mark style="color:blue;">Command</mark>
 
-➡️  **`@catana-dev`**<mark style="color:purple;">**`bump`**</mark><mark style="color:orange;">**`[argument]`**</mark>
+➡️  **`@catanacorp`**<mark style="color:purple;">**`bump`**</mark><mark style="color:orange;">**`[argument]`**</mark>
 
 Catana will edit the TODO in the repository, open a Pull Request, and assign it to the user who invoked the command.&#x20;
 
@@ -31,9 +31,9 @@ Once the Pull Request is merged the Todo Item record in Catana's database will b
 
 This command accepts arguments such as:
 
-* `@catana-dev`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`tomorrow`**</mark>
-* `@catana-dev`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`next week`**</mark>
-* `@catana-dev`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`next month`**</mark>
-* `@catana-dev`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`2023-06-18`**</mark>   (Where 2023-06-18 can be any date)
+* `@catanacorp`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`tomorrow`**</mark>
+* `@catanacorp`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`next week`**</mark>
+* `@catanacorp`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`next month`**</mark>
+* `@catanacorp`<mark style="color:purple;">`bump`</mark><mark style="color:orange;">**`2023-06-18`**</mark>   (Where 2023-06-18 can be any date)
 
 <figure><img src="../.gitbook/assets/bump-examples.png" alt="" width="563"><figcaption></figcaption></figure>

--- a/commands/done.md
+++ b/commands/done.md
@@ -12,7 +12,7 @@ The only action required is to remove them from your project, as they can be con
 
 #### <mark style="color:blue;">Command</mark>
 
-➡️  **`@catana-dev`**<mark style="color:purple;">**`done`**</mark>
+➡️  **`@catanacorp`**<mark style="color:purple;">**`done`**</mark>
 
 Catana will remove the TODO from the repository, open a Pull Request, and assign it to the user who invoked the command.
 

--- a/commands/overview.md
+++ b/commands/overview.md
@@ -24,7 +24,7 @@ When a user types a command, Catana will perform the requested operation and ope
 
 ### <mark style="color:blue;">Usage</mark>
 
-To perform a command, reply in a comment to a GitHub issue previously opened by Catana and **type `@catana-dev` followed by the command name**.\
+To perform a command, reply in a comment to a GitHub issue previously opened by Catana and **type `@catanacorp` followed by the command name**.\
 
 
 


### PR DESCRIPTION
- `@catana-dev` used to map to the bot's name but GitHub doesn't recognize it as an handle and doesn't format it correctly. Using `@catanacorp` which maps to the org corrects it.